### PR TITLE
chore: add AGENTS.md and fix pnpm 10 build scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+Voyagely is a React 18 + TypeScript SPA for collaborative group travel planning. It uses Vite 6 as build tool, pnpm as package manager, and Supabase (cloud-hosted) as the backend (Auth, Postgres, Realtime). See `README.md` for the full tech stack and available scripts.
+
+### Running the dev environment
+
+- **Dev server**: `pnpm dev` starts Vite on port 5173.
+- **Lint**: `pnpm lint`
+- **Type check**: `pnpm typecheck` or `pnpm type-check`
+- **Unit tests**: `pnpm test:run` (96 tests across 21 files)
+- **E2E tests**: `pnpm e2e` (requires Playwright chromium; install with `npx playwright install --with-deps chromium`)
+- **Combined check**: `pnpm check` runs lint + type-check + test:run
+
+### Gotchas
+
+- **pnpm 10 build scripts**: pnpm 10 does not run postinstall scripts by default. The `package.json` includes `pnpm.onlyBuiltDependencies` to allowlist `esbuild`, `msw`, `core-js`, and `protobufjs`. Without this, esbuild won't install its platform binary and Vite will fail.
+- **Supabase credentials**: The app requires `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in `.env.local`. Without real credentials, the app renders (landing, auth pages) but API calls fail with placeholder fallbacks. Copy `.env.example` to `.env.local` and fill in real values if available.
+- **Husky hooks**: Pre-commit runs `lint-staged` (ESLint + Prettier + related Vitest tests). Pre-push runs `pnpm typecheck && pnpm test:run`. When committing from a cloud agent, you may want to skip hooks with `--no-verify` if they cause issues, but prefer running checks manually before pushing.
+- **E2E tests** require `E2E_TEST_EMAIL` and `E2E_TEST_PASSWORD` env vars plus a real Supabase instance to pass authentication flows.
+- **Optional API keys**: OpenWeather, Google Maps, OpenAI, Sentry, and PostHog features degrade gracefully without their respective API keys.

--- a/package.json
+++ b/package.json
@@ -126,5 +126,13 @@
     "*.{json,md,css,scss}": [
       "prettier --write"
     ]
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "core-js",
+      "esbuild",
+      "msw",
+      "protobufjs"
+    ]
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `AGENTS.md` with Cursor Cloud-specific development instructions (dev server, lint, test, gotchas)
- Add `pnpm.onlyBuiltDependencies` to `package.json` to allowlist `esbuild`, `msw`, `core-js`, and `protobufjs` build scripts (required for pnpm 10 compatibility)

## Context

pnpm 10 no longer runs postinstall scripts by default. Without explicitly allowing `esbuild`'s postinstall, the platform-specific binary doesn't get installed and Vite fails to start. The `pnpm.onlyBuiltDependencies` field in `package.json` is the non-interactive way to approve these build scripts.

## Test Plan

- [x] `pnpm install` completes without warnings about ignored build scripts
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:run` passes (96 tests, 21 files)
- [x] `pnpm dev` starts Vite dev server on port 5173
- [x] Manual GUI testing: landing page, signup/login, dark mode, i18n all functional

## Demo

[voyagely_app_demo.mp4](https://cursor.com/agents/bc-b51dbfaf-7d32-467d-8629-719bc7dfe7d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvoyagely_app_demo.mp4)

Landing page with warm orange design system:
[Landing page hero section](https://cursor.com/agents/bc-b51dbfaf-7d32-467d-8629-719bc7dfe7d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page_hero.webp)

Dark mode support:
[Dark mode enabled](https://cursor.com/agents/bc-b51dbfaf-7d32-467d-8629-719bc7dfe7d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdark_mode.webp)

French i18n translation:
[French translation](https://cursor.com/agents/bc-b51dbfaf-7d32-467d-8629-719bc7dfe7d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrench_i18n.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b51dbfaf-7d32-467d-8629-719bc7dfe7d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b51dbfaf-7d32-467d-8629-719bc7dfe7d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

